### PR TITLE
fix: re-enable rgb_matrix on suspend wakeup

### DIFF
--- a/keyboards/shortcut/bridge75/bridge75.c
+++ b/keyboards/shortcut/bridge75/bridge75.c
@@ -101,7 +101,9 @@ void suspend_wakeup_init_kb(void) {
     #ifdef RGB_MATRIX_ENABLE
     gpio_write_pin_low(LED_POWER_EN_PIN);
 
+    // enable RGB on wakeup and force a repaint
     rgb_matrix_enable();
+    rgb_matrix_set_color_all(0, 0, 0);
     #endif
 
     wireless_devs_change(wireless_get_current_devs(), wireless_get_current_devs(), false);

--- a/keyboards/shortcut/bridge75/bridge75.c
+++ b/keyboards/shortcut/bridge75/bridge75.c
@@ -100,6 +100,8 @@ void suspend_power_down_kb(void) {
 void suspend_wakeup_init_kb(void) {
     #ifdef RGB_MATRIX_ENABLE
     gpio_write_pin_low(LED_POWER_EN_PIN);
+
+    rgb_matrix_enable();
     #endif
 
     wireless_devs_change(wireless_get_current_devs(), wireless_get_current_devs(), false);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
it's my first time with a keyboard firmware and QMK code. I've tested the change and it seems to resolve the issue. I've used chatgpt to understand how QMK works... if it isn't a good change, sorry 😅 

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* On sleep, the rgb didn't work. 

Reproduction:
- Press caps lock and check RGB ligth up
- Wait to enter on sleep mode
- Awake it pressing any key
- Check that Caps lock never light up again

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
