### PR TITLE
neo80_trimode: Do not keep LEDs on continuously

### DIFF
--- a/keyboards/neo/neo80_trimode/config.h
+++ b/keyboards/neo/neo80_trimode/config.h
@@ -9,6 +9,11 @@
  * greater than 3 seconds we select that device and go into pairing mode.
  */
 #define WIRELESS_TAPPING_TERM 3000
+/*
+ * After a connection, light the LED under the number key associated with the
+ * device for 5 seconds, then turn the LED off to save power.
+ */
+#define WIRELESS_LED_CONNECT_CONFIRM_TIME 5000
 
 /* LEDS */
 #define LED_BLINK_FAST_PERIOD_MS 300


### PR DESCRIPTION
The original firmware kept LEDs under the 1-4 keys steadily lit for a short while on successful connection, but then turned them off to save power.

Implement the same behavior by saving the time of last change, and turning the LED associated with the currently connected device off after a certain timeout after that last change.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
